### PR TITLE
Deadlocked - Easier for waste pickers to find out how to navigate to profile

### DIFF
--- a/eml/components/navBar/NavBar.jsx
+++ b/eml/components/navBar/NavBar.jsx
@@ -69,7 +69,7 @@ export default function NavBar() {
 					headerShown: false,
 					tabBarIcon: ({ color }) => ( // Pass the color as a parameter to the icon component
 						<Icon
-							size={17}
+							size={25}
 							name="home-outline"
 							type="material-community"
 							color={color} // Use the color parameter here
@@ -87,7 +87,7 @@ export default function NavBar() {
 					headerShown: false,
 					tabBarIcon: ({ color }) => ( // Pass the color as a parameter to the icon component
 						<Icon
-							size={17}
+							size={25}
 							name="compass-outline"
 							type="material-community"
 							color={color} // Use the color parameter here
@@ -105,7 +105,7 @@ export default function NavBar() {
 					headerShown: false,
 					tabBarIcon: ({ color }) => ( // Pass the color as a parameter to the icon component
 						<Icon
-							size={17}
+							size={34}
 							name="account-outline"
 							type="material-community"
 							color={color} // Use the color parameter here

--- a/eml/components/navBar/NavBar.jsx
+++ b/eml/components/navBar/NavBar.jsx
@@ -23,7 +23,7 @@ export default function NavBar() {
 				tabBarActiveTintColor: 'black',
 				tabBarActiveBackgroundColor: tailwindConfig.theme.colors.cyanBlue,
 				tabBarLabelStyle: {
-					fontSize: 12,
+					fontSize: 14,
 				},
 
 				tabBarStyle: {


### PR DESCRIPTION
## Description

Improved the sizes of the navbar icons and text to make it easier for wastepickers to navigate to the different menus, specifically their profile, which has an even bigger icon than the two others.

## Changes

Updated size of 'Course Screen' and 'Explore' icons from 17 to 25. 
Updated size of 'Profile' icon from 17 to 34.
Changed size of text in navigation bar from 12px to 14px(caption/small to caption/medium according to figma design system.)

## Related Issues

https://github.com/orgs/Educado-App/projects/14/views/12?pane=issue&itemId=78205040

## Checklist

- [x] Code has been tested locally and passes all relevant tests.
- [x] Documentation has been updated to reflect the changes, if applicable.
- [x] Code follows the established coding style and guidelines of the project.
- [x] All new and existing tests related to the changes have passed.
- [x] Any necessary dependencies or new packages have been properly documented.
- [x] Pull request title and description are clear and descriptive.
- [ ] Reviewers have been assigned to the pull request.
- [x] Any potential security implications have been considered and addressed.
- [x] Performance impact of the changes has been evaluated, if relevant.

## Screenshots (if applicable)

Before:
![image](https://github.com/user-attachments/assets/7cc0faff-0a32-413d-817a-91d199fc776f)

After:
![image](https://github.com/user-attachments/assets/2c744eb4-a883-41a0-bc8a-bf98446589b5)


## If mobile/frontend pull request, what version of the backend is it stable, and running on? 

Branch: main

Commit id:  9a089e3


## Notes for Reviewers