### PR TITLE
Fixed disapeering category bars in explorer - issue #128

### DIFF
--- a/eml/components/explore/FilterNavBar.jsx
+++ b/eml/components/explore/FilterNavBar.jsx
@@ -35,9 +35,7 @@ function FilterNavBar({ onChangeText, onCategoryChange, searchPlaceholder }) {
 				<ScrollView horizontal showsHorizontalScrollIndicator={false}>
 					<View className="flex items-center p-2 ">
 						<View className="flex-row overflow-x-auto">
-							{categories
-								.filter((category) => category.label.toLowerCase().includes(searchText.toLowerCase()))
-								.map((category) => (
+							{categories.map((category) => (
 									<Pressable
 										key={category.label}
 										onPress={() => handleCategorySelect(category.label)}

--- a/eml/components/explore/FilterNavBar.jsx
+++ b/eml/components/explore/FilterNavBar.jsx
@@ -36,22 +36,22 @@ function FilterNavBar({ onChangeText, onCategoryChange, searchPlaceholder }) {
 					<View className="flex items-center p-2 ">
 						<View className="flex-row overflow-x-auto">
 							{categories.map((category) => (
-									<Pressable
-										key={category.label}
-										onPress={() => handleCategorySelect(category.label)}
+								<Pressable
+									key={category.label}
+									onPress={() => handleCategorySelect(category.label)}
+									className={`${selectedCategory === category.label
+										? 'bg-primary_custom'
+										: 'border-2'
+									} px-2 py-2 rounded-lg border-projectGray border-[1px] mr-2 items-center justify-center`}
+								>
+									<Text
 										className={`${selectedCategory === category.label
-											? 'bg-primary_custom'
-											: 'border-2'
-										} px-2 py-2 rounded-lg border-projectGray border-[1px] mr-2 items-center justify-center`}
-									>
-										<Text
-											className={`${selectedCategory === category.label
-												? 'text-projectWhite font-bold'
-												: 'text-projectGray'
-											}`}
-										>{category.label}</Text>
-									</Pressable>
-								))}
+											? 'text-projectWhite font-bold'
+											: 'text-projectGray'
+										}`}
+									>{category.label}</Text>
+								</Pressable>
+							))}
 						</View>
 					</View>
 				</ScrollView>


### PR DESCRIPTION
##Description##
Currently when searching in explorer page categorys are also filtered out, this is not the desired behavior.

Fixed Issue: https://github.com/Educado-App/educado-mobile/issues/128

Before: 

https://github.com/user-attachments/assets/bb0de966-29f8-4095-9ab3-913b0141c1b9

After:

https://github.com/user-attachments/assets/71250868-7de5-4b3a-b855-92516d7ea958

